### PR TITLE
Important improvements&fixes

### DIFF
--- a/Controls/PanZoom.xaml
+++ b/Controls/PanZoom.xaml
@@ -96,12 +96,12 @@
                     <Grid>
                         <Grid VerticalAlignment="Top" HorizontalAlignment="Left">
                             <Grid.Background>
-                                <DrawingBrush TileMode="Tile" Viewport="0,0,60,60" 
+                                <DrawingBrush TileMode="Tile" Viewport="0,0,2,2" 
                                       ViewportUnits="Absolute">
                                     <DrawingBrush.Drawing>
                                         <DrawingGroup>
-                                            <GeometryDrawing Brush="#F8F8F8" Geometry="M5,5 L0,5 0,10 5,10 5,5 10,5 10,0 5,0 Z"/>
-                                            <GeometryDrawing Brush="White" Geometry="M0,0 L0,5 0,10 0,5, 10,5 10,10 5,10 5,0 Z"/>
+                                            <GeometryDrawing Brush="White" Geometry="M0,0 L0,0 0,10 10,10 10,0 Z"/>
+                                            <GeometryDrawing Brush="#b9b9b9" Geometry="M0,0 L0,0 0,5, 10,5 10,10 5,10 5,0 Z"/>
                                         </DrawingGroup>
                                     </DrawingBrush.Drawing>
                                 </DrawingBrush>

--- a/Controls/PanZoom.xaml
+++ b/Controls/PanZoom.xaml
@@ -111,7 +111,7 @@
                                     <ScaleTransform ScaleX="{Binding InputPack.EditingTexture.ScaleFactor}" ScaleY="{Binding InputPack.EditingTexture.ScaleFactor}"/>
                                 </TransformGroup>
                             </Grid.LayoutTransform>
-                            <Image Source="{Binding InputPack.EditingTexture.TexturePath, Converter={StaticResource PathToImageValueConverter}}"  Width="{Binding InputPack.EditingTexture.ImageWidth}" Height="{Binding InputPack.EditingTexture.ImageHeight}" Stretch="Fill" x:Name="Img"
+                            <Image Source="{Binding InputPack.EditingTexture.TexturePath, Converter={StaticResource PathToImageValueConverter}}"  Width="{Binding InputPack.EditingTexture.ImageWidth}" Height="{Binding InputPack.EditingTexture.ImageHeight}" Stretch="Fill" x:Name="Img" RenderOptions.BitmapScalingMode="NearestNeighbor"
                                 VerticalAlignment="Top" HorizontalAlignment="Left" UseLayoutRounding="True" SnapsToDevicePixels="True">
                             </Image>
                         </Grid>

--- a/Controls/PanZoom.xaml.cs
+++ b/Controls/PanZoom.xaml.cs
@@ -81,11 +81,11 @@ namespace DolphinDynamicInputTextureCreator.Controls
         {
             if (e.Delta > 0)
             {
-                ViewModel.InputPack.EditingTexture.ScaleFactor += 0.1;
+                ViewModel.InputPack.EditingTexture.ScaleFactor *= 1.1;
             }
             else
             {
-                ViewModel.InputPack.EditingTexture.ScaleFactor -= 0.1;
+                ViewModel.InputPack.EditingTexture.ScaleFactor /= 1.1;
             }
         }
     }

--- a/Controls/Resizer.xaml.cs
+++ b/Controls/Resizer.xaml.cs
@@ -55,69 +55,86 @@ namespace DolphinDynamicInputTextureCreator.Controls
 
         private void UpperLeft_DragDelta(object sender, DragDeltaEventArgs e)
         {
-            double old_x = X;
-            double old_y = Y;
-            X = old_x + e.HorizontalChange;
-            Y = old_y + e.VerticalChange;
-
-            double horizontal_change = X - old_x;
-            double vertical_change = Y - old_y;
-
-            ItemHeight = ItemHeight + vertical_change * -1;
-            ItemWidth = ItemWidth + horizontal_change * -1;
-
-            if (ItemHeight < RegionMinHeight)
-                ItemHeight = RegionMinHeight;
-
-            if (ItemWidth < RegionMinWidth)
-                ItemWidth = RegionMinWidth;
+            Expand_Up(e.VerticalChange);
+            Expand_Left(e.HorizontalChange);
         }
 
         private void UpperRight_DragDelta(object sender, DragDeltaEventArgs e)
         {
-            double old_y = Y;
-            Y = old_y + e.VerticalChange;
-
-            double vertical_change = Y - old_y;
-
-            ItemHeight = ItemHeight + vertical_change * -1;
-            ItemWidth = ItemWidth + e.HorizontalChange;
-
-            if (ItemHeight < RegionMinHeight)
-                ItemHeight = RegionMinHeight;
-
-            if (ItemWidth < RegionMinWidth)
-                ItemWidth = RegionMinWidth;
+            Expand_Up(e.VerticalChange);
+            Expand_Right(e.HorizontalChange);
         }
 
         private void LowerLeft_DragDelta(object sender, DragDeltaEventArgs e)
         {
-            double old_x = X;
-            X = old_x + e.HorizontalChange;
-
-            double horizontal_change = X - old_x;
-
-            ItemHeight = ItemHeight + e.VerticalChange;
-            ItemWidth = ItemWidth + horizontal_change * -1;
-
-            if (ItemHeight < RegionMinHeight)
-                ItemHeight = RegionMinHeight;
-
-            if (ItemWidth < RegionMinWidth)
-                ItemWidth = RegionMinWidth;
+            Expand_Down(e.VerticalChange);
+            Expand_Left(e.HorizontalChange);
         }
 
         private void LowerRight_DragDelta(object sender, DragDeltaEventArgs e)
         {
-            ItemHeight = ItemHeight + e.VerticalChange;
-            ItemWidth = ItemWidth + e.HorizontalChange;
-
-            if (ItemHeight < RegionMinHeight)
-                ItemHeight = RegionMinHeight;
-
-            if (ItemWidth < RegionMinWidth)
-                ItemWidth = RegionMinWidth;
+            Expand_Down(e.VerticalChange);
+            Expand_Right(e.HorizontalChange);
         }
+
+        private void Expand_Up(double VerticalChange)
+        {
+            // Change only when it makes sense
+            if (ItemHeight - VerticalChange < RegionMinHeight)
+                return;
+
+            double old_y = Y;
+
+            //it was the easiest way...
+            double old_Height = ItemHeight;
+            ItemHeight -= VerticalChange;
+
+            Y += VerticalChange;
+
+            ItemHeight = old_Height - (Y - old_y);
+        }
+
+        private void Expand_Down(double VerticalChange)
+        {
+            // Change only when it makes sense
+            if (ItemHeight + VerticalChange < RegionMinHeight)
+            {
+                ItemHeight = RegionMinHeight;
+                return;
+            }
+
+            ItemHeight = ItemHeight + VerticalChange;
+        }
+
+        private void Expand_Left(double HorizontalChange)
+        {
+            // Change only when it makes sense
+            if (ItemWidth - HorizontalChange < RegionMinWidth)
+                return;
+
+            double old_x = X;
+
+            //it was the easiest way...
+            double old_width = ItemWidth;
+            ItemWidth -= HorizontalChange;
+
+            X += HorizontalChange;
+
+            ItemWidth = old_width - (X - old_x);
+        }
+
+        private void Expand_Right(double HorizontalChange)
+        {
+            // Change only when it makes sense
+            if (ItemWidth + HorizontalChange < RegionMinWidth)
+            {
+                ItemWidth = RegionMinWidth;
+                return;
+            }
+
+            ItemWidth = ItemWidth + HorizontalChange;
+        }
+
 
         private void Center_DragDelta(object sender, DragDeltaEventArgs e)
         {

--- a/Controls/TexturePicker.xaml
+++ b/Controls/TexturePicker.xaml
@@ -45,7 +45,7 @@
                                                         <RowDefinition />
                                                     </Grid.RowDefinitions>
                                                     <Viewbox Grid.Row="0" HorizontalAlignment="Center">
-                                                        <Image Source="{Binding TexturePath, Converter={StaticResource PathToImageValueConverter}}" HorizontalAlignment="Center" />
+                                                        <Image Source="{Binding TexturePath, Converter={StaticResource PathToImageValueConverter}}" HorizontalAlignment="Center" RenderOptions.BitmapScalingMode="NearestNeighbor" />
                                                     </Viewbox>
                                                     <Grid Grid.Row="0">
                                                         <Grid.RowDefinitions>

--- a/Data/DynamicInputPack.cs
+++ b/Data/DynamicInputPack.cs
@@ -834,27 +834,31 @@ namespace DolphinDynamicInputTextureCreator.Data
                     writer.WriteEndObject();
                     #endregion
 
-                    #region HOST KEYS
-                    writer.WritePropertyName("host_controls");
-                    writer.WriteStartObject();
-                    foreach (var device in _host_devices)
+                    #region HOST    
+                    // Only create if devices are assigned.   
+                    if (_host_devices.Count != 0)
                     {
-                        // Skip devices with no mapped keys
-                        if (device.HostKeys.Count == 0)
-                        {
-                            continue;
-                        }
-
-                        writer.WritePropertyName(device.Name);
+                        writer.WritePropertyName("host_controls");
                         writer.WriteStartObject();
-                        foreach (var key in device.HostKeys)
+                        foreach (var device in _host_devices)
                         {
-                            writer.WritePropertyName(key.Name);
-                            writer.WriteValue(GetHostDeviceKeyTextureLocation("", device, key));
+                            // Skip devices with no mapped keys
+                            if (device.HostKeys.Count == 0)
+                            {
+                                continue;
+                            }
+
+                            writer.WritePropertyName(device.Name);
+                            writer.WriteStartObject();
+                            foreach (var key in device.HostKeys)
+                            {
+                                writer.WritePropertyName(key.Name);
+                                writer.WriteValue(GetHostDeviceKeyTextureLocation("", device, key));
+                            }
+                            writer.WriteEndObject();
                         }
                         writer.WriteEndObject();
                     }
-                    writer.WriteEndObject();
                     #endregion
 
                     writer.WriteEndObject();

--- a/Data/DynamicInputPack.cs
+++ b/Data/DynamicInputPack.cs
@@ -727,14 +727,22 @@ namespace DolphinDynamicInputTextureCreator.Data
         {
             foreach (DynamicInputTexture texture in _textures)
             {
+                string destImagePath = Path.Combine(location, GetImageName(texture.TexturePath));
+
                 // Unlikely that we get here but skip textures that don't exist
                 if (!File.Exists(texture.TexturePath))
                 {
                     continue;
                 }
 
+                // Prevents the file from trying to overwrite itself.
+                if (texture.TexturePath == destImagePath)
+                {
+                    continue;
+                }
+
                 const bool overwrite = true;
-                File.Copy(texture.TexturePath, Path.Combine(location, GetImageName(texture.TexturePath)), overwrite);
+                File.Copy(texture.TexturePath, destImagePath, overwrite);
             }
 
             foreach (var device in _host_devices)

--- a/Data/RectRegion.cs
+++ b/Data/RectRegion.cs
@@ -63,6 +63,13 @@
                 _x = value;
                 if (_x < 0)
                     _x = 0;
+
+                if (OwnedTexture != null)
+                {
+                    if (_x + Width > OwnedTexture.ImageWidth)
+                        _x = OwnedTexture.ImageWidth - Width;
+                }
+
                 OnPropertyChanged(nameof(X));
                 OnPropertyChanged(nameof(ScaledX));
             }
@@ -77,6 +84,13 @@
                 _y = value;
                 if (_y < 0)
                     _y = 0;
+
+                if (OwnedTexture != null)
+                {
+                    if (_y + Height > OwnedTexture.ImageHeight)
+                        _y = OwnedTexture.ImageHeight - Height;
+                }
+
                 OnPropertyChanged(nameof(Y));
                 OnPropertyChanged(nameof(ScaledY));
             }

--- a/ViewModels/PanZoomViewModel.cs
+++ b/ViewModels/PanZoomViewModel.cs
@@ -79,10 +79,11 @@ namespace DolphinDynamicInputTextureCreator.ViewModels
                 return;
             }
 
+            //prevents a region from being created in another region.
             foreach (Data.RectRegion r in InputPack.EditingTexture.Regions)
             {
-                if (p.X > r.ScaledX && p.X < (r.X + r.ScaledWidth) &&
-                    p.Y > r.ScaledY && p.Y < (r.Y + r.ScaledHeight))
+                if (p.X >= r.X && p.X < (r.X + r.Width) &&
+                    p.Y >= r.Y && p.Y < (r.Y + r.Height))
                 {
                     _currently_creating_region = null;
                     return;


### PR DESCRIPTION
these are very minor adjustments that mainly fix bugs or make work easier.
- fixes a crash when an image file tries to overwrite itself. 
   > this is the case when you try to export to the folder from which the files were loaded. now only the missing files will be created.
- Set the image filter to "Nearest Neighbor".
- prevents a key from being pushed outside the canvas. 
   > the last [push](https://github.com/iwubcode/DolphinDynamicInputTextureCreator/pull/8/commits/155721abdd44ba35c4d66af23433cd7e99770975) fixes the mistake, that I had specified width and not height as the limit for the height.
- white background replaced by a simple pixel grid.
   > the grid is exactly 1x1 pixel and makes orientation easier
- fixes the problem that no regions can be created if one exists at 0x0
   > I'm not sure what the line was originally intended to do, the only thing it did is prevent you from creating new regions. I'm sure that wasn't what you wanted.
- zoom changed from constant to exponential
   > before, the zoom was useless for resolutions that were too large or too small
- host_controls are not created in json if not used.