### PR TITLE
Subpixels settings

### DIFF
--- a/Data/RectRegion.cs
+++ b/Data/RectRegion.cs
@@ -117,8 +117,8 @@ namespace DolphinDynamicInputTextureCreator.Data
                     if ((_height + Y) > OwnedTexture.ImageHeight)
                         _height = OwnedTexture.ImageHeight - Y;
                 }
-                if (_height < 0)
-                    _height = 1;
+                if (_height <= 0)
+                    _height = GetMinHeight();
                 OnPropertyChanged(nameof(Height));
                 OnPropertyChanged(nameof(ScaledHeight));
             }
@@ -136,11 +136,21 @@ namespace DolphinDynamicInputTextureCreator.Data
                     if ((_width + X) > OwnedTexture.ImageWidth)
                         _width = OwnedTexture.ImageWidth - X;
                 }
-                if (_width < 0)
-                    _width = 1;
+                if (_width <= 0)
+                    _width = GetMinWidth();
                 OnPropertyChanged(nameof(Width));
                 OnPropertyChanged(nameof(ScaledWidth));
             }
+        }
+
+        private double GetMinHeight()
+        {
+            return GetMinWidth();
+        }
+
+        private double GetMinWidth()
+        {
+            return Math.Pow(10.0, - DecimalPlaces);
         }
 
         [JsonIgnore]

--- a/Data/RectRegion.cs
+++ b/Data/RectRegion.cs
@@ -1,9 +1,16 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
+﻿using System;
 
 namespace DolphinDynamicInputTextureCreator.Data
 {
     public class RectRegion : Other.PropertyChangedBase
     {
+
+        /// <summary>
+        /// this determines the sub pixel value, 0 uses only full pixels.
+        /// </summary>
+        public static int DecimalPlaces { get; set; } = 0;
+
         private EmulatedDevice _emulated_device;
         public EmulatedDevice Device
         {
@@ -62,7 +69,7 @@ namespace DolphinDynamicInputTextureCreator.Data
             get { return _x; }
             set
             {
-                _x = value;
+                _x = Math.Round(value, DecimalPlaces);
                 if (_x < 0)
                     _x = 0;
 
@@ -83,7 +90,7 @@ namespace DolphinDynamicInputTextureCreator.Data
             get { return _y; }
             set
             {
-                _y = value;
+                _y = Math.Round(value, DecimalPlaces);
                 if (_y < 0)
                     _y = 0;
 
@@ -104,7 +111,7 @@ namespace DolphinDynamicInputTextureCreator.Data
             get { return _height; }
             set
             {
-                _height = value;
+                _height = Math.Round(value, DecimalPlaces);
                 if (OwnedTexture != null)
                 {
                     if ((_height + Y) > OwnedTexture.ImageHeight)
@@ -123,7 +130,7 @@ namespace DolphinDynamicInputTextureCreator.Data
             get { return _width; }
             set
             {
-                _width = value;
+                _width = Math.Round(value, DecimalPlaces);
                 if (OwnedTexture != null)
                 {
                     if ((_width + X) > OwnedTexture.ImageWidth)

--- a/Data/RegionBrush.cs
+++ b/Data/RegionBrush.cs
@@ -48,6 +48,21 @@ namespace DolphinDynamicInputTextureCreator.Data
                 OnPropertyChanged(nameof(FillRegion));
             }
         }
+
+        /// <summary>
+        /// whether subpixels are used.
+        /// </summary>
+        private bool _subpixel;
+        public bool Subpixel
+        {
+            get { return _subpixel; }
+            set
+            {
+                _subpixel = value;
+                RectRegion.DecimalPlaces = value ? 1 : 0;
+                OnPropertyChanged(nameof(Subpixel));
+            }
+        }
         #endregion
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -89,6 +89,7 @@
                     </ComboBox.Style>
                 </ComboBox>
                 <CheckBox Margin="5 0 5 0" Content="Fill texture?" IsChecked="{Binding SelectedRegionBrush.FillRegion}" VerticalAlignment="Center" />
+                <CheckBox Margin="5 0 5 0" Content="Use subpixel?" IsChecked="{Binding SelectedRegionBrush.Subpixel}" VerticalAlignment="Center" />
             </StackPanel>
             <controls:PanZoom x:Name="PanZoom" Grid.Row="1"></controls:PanZoom>
         </Grid>


### PR DESCRIPTION
required [Important improvements&fixes #8](https://github.com/iwubcode/DolphinDynamicInputTextureCreator/pull/8)

- prevents subpixels, so that only full pixels are usable.
- makes it possible to activate subpixels again via an option
- Since the changes make it very easy to create a region with size 0x0, the minimum size for regions is set to 0.1x0.1.