### PR TITLE
uses the gameId to create a <GameID>.txt

### DIFF
--- a/Controls/Metadata.xaml
+++ b/Controls/Metadata.xaml
@@ -29,6 +29,8 @@
             <TextBox Text="{Binding GeneratedFolderName, Mode=TwoWay}" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="4,0"/>
             <Label Content="Preserve aspect ratio:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalContentAlignment="Right"/>
             <CheckBox IsChecked="{Binding PreserveAspectRatio, Mode=TwoWay}" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="4,0"/>
+            <Label Content="Game ID:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" HorizontalContentAlignment="Right"/>
+            <TextBox Text="{Binding GameID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="4,0"/>
 
         </Grid>
     </Grid>

--- a/Data/DynamicInputPack.cs
+++ b/Data/DynamicInputPack.cs
@@ -71,6 +71,24 @@ namespace DolphinDynamicInputTextureCreator.Data
                 OnPropertyChanged(nameof(PreserveAspectRatio));
             }
         }
+
+        private string _game_id = "";
+        public string GameID
+        {
+            get
+            {
+                return _game_id;
+            }
+            set
+            {
+                if (value.Length <= 6)
+                {
+                    _game_id = value.ToUpper();
+                }
+
+                OnPropertyChanged(nameof(GameID));
+            }
+        }
         #endregion
 
         #region DYNAMIC TEXTURE PROPERTIES

--- a/Data/DynamicInputPack.cs
+++ b/Data/DynamicInputPack.cs
@@ -744,6 +744,7 @@ namespace DolphinDynamicInputTextureCreator.Data
         {
             WriteJson(Path.Combine(location, GeneratedJsonName+".json"));
             WriteImages(location);
+            WriteGameID(location);
         }
 
         #region JSON WRITER HELPERS
@@ -760,6 +761,18 @@ namespace DolphinDynamicInputTextureCreator.Data
             return Path.Combine(device_location, Path.GetFileName(key.TexturePath));
         }
         #endregion
+
+        /// <summary>
+        /// creates a GameID.txt so that the pack is recognized.
+        /// </summary>
+        private void WriteGameID(string location)
+        {
+            if (GameID.Length < 3) return;
+
+            location = Path.Combine(location, "GameID");
+            Directory.CreateDirectory(location);
+            File.Create(Path.Combine(location, GameID + ".txt")).Dispose();
+        }
 
         private void WriteImages(string location)
         {


### PR DESCRIPTION
- adds a GameID section to the metadata window.
- if the GameID is specified, a corresponding `<GameID>`.txt will be created when exporting a pack.