### PR TITLE
additional functions for the user interface

### DIFF
--- a/Controls/EmulatedKeyList.xaml
+++ b/Controls/EmulatedKeyList.xaml
@@ -14,7 +14,14 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Button Grid.Row="0" Content="Add Emulated Key" Command="{Binding AddKeyCommand}" />
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="4*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="0" Content="Add Emulated Key" Command="{Binding AddKeyCommand}" />
+            <Button Grid.Column="1" Content="Add All" Command="{Binding AddAllKeyCommand}" />
+        </Grid>
         <ScrollViewer Grid.Row="1">
             <ItemsControl ItemsSource="{Binding EmulatedKeys}">
                 <ItemsControl.ItemsPanel>

--- a/Controls/HostKeyList.xaml
+++ b/Controls/HostKeyList.xaml
@@ -23,7 +23,7 @@
  
             <Button Grid.Column="1" Content="Add Host Key(s)" x:Name="AddHostKey" Click="AddHostKey_Click" />
         </Grid>
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1" AllowDrop="True" Drop="AddHostKey_DragEnter">
             <ItemsControl ItemsSource="{Binding HostKeys}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/Controls/HostKeyList.xaml.cs
+++ b/Controls/HostKeyList.xaml.cs
@@ -52,5 +52,24 @@ namespace DolphinDynamicInputTextureCreator.Controls
                 }
             }
         }
+
+        /// <summary>
+        /// catches dropped files and adds them to the HostKey list.
+        /// </summary>
+        private void AddHostKey_DragEnter(object sender, DragEventArgs e)
+        {
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
+            foreach (string file in files)
+            {
+                if (System.IO.Path.GetExtension(file).ToLower() == ".png")
+                {
+                    HostDevice.HostKeys.Add(new Data.HostKey
+                    {
+                        Name = "",
+                        TexturePath = file
+                    });
+                }
+            }
+        }
     }
 }

--- a/Controls/PanZoom.xaml.cs
+++ b/Controls/PanZoom.xaml.cs
@@ -77,15 +77,30 @@ namespace DolphinDynamicInputTextureCreator.Controls
             }
         }
 
+        /// <summary>
+        /// ScrollViewer mouse wheel functions
+        /// </summary>
         private void Grid_MouseWheel(object sender, MouseWheelEventArgs e)
         {
-            if (e.Delta > 0)
+            // Mouse wheel + Ctrl = zoom
+            if (Keyboard.IsKeyDown(Key.LeftCtrl))
             {
-                ViewModel.InputPack.EditingTexture.ScaleFactor *= 1.1;
+                e.Handled = true;
+                if (e.Delta > 0)
+                {
+                    ViewModel.InputPack.EditingTexture.ScaleFactor *= 1.1;
+                }
+                else
+                {
+                    ViewModel.InputPack.EditingTexture.ScaleFactor /= 1.1;
+                }
             }
-            else
+            // Mouse wheel + Shift = horizontal scrolling
+            if (Keyboard.IsKeyDown(Key.LeftShift))
             {
-                ViewModel.InputPack.EditingTexture.ScaleFactor /= 1.1;
+                e.Handled = true;
+                double offset = scr.HorizontalOffset;
+                scr.ScrollToHorizontalOffset(offset+e.Delta/2);
             }
         }
     }

--- a/Controls/TexturePicker.xaml
+++ b/Controls/TexturePicker.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ScrollViewer Grid.Row="0">
+        <ScrollViewer Grid.Row="0" AllowDrop="True" Drop="AddTexture_DragEnter">
             <ItemsControl ItemsSource="{Binding Textures}" HorizontalAlignment="Stretch">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/Controls/TexturePicker.xaml.cs
+++ b/Controls/TexturePicker.xaml.cs
@@ -52,5 +52,24 @@ namespace DolphinDynamicInputTextureCreator.Controls
                 }
             }
         }
+
+        /// <summary>
+        /// catches dropped files and adds them to the texture list.
+        /// </summary>
+        private void AddTexture_DragEnter(object sender, DragEventArgs e)
+        {
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
+            foreach (string file in files)
+            {
+                if (System.IO.Path.GetExtension(file).ToLower() == ".png")
+                {
+                    InputPack.Textures.Add(new Data.DynamicInputTexture
+                    {
+                        TextureHash = InputPack.ShouldGetHashFromTextureFilename ? System.IO.Path.GetFileName(file) : "hash value",
+                        TexturePath = file
+                    });
+                }
+            }
+        }
     }
 }

--- a/Data/DynamicInputTexture.cs
+++ b/Data/DynamicInputTexture.cs
@@ -56,6 +56,11 @@ namespace DolphinDynamicInputTextureCreator.Data
                         _image_height = bmp.Height;
                         _image_width = bmp.Width;
                     }
+                    //Automatically select suitable zoom.
+                    if (ScaleFactor == 1)
+                    {
+                        SetInitialZoom();
+                    }
                 }
             }
         }
@@ -80,6 +85,7 @@ namespace DolphinDynamicInputTextureCreator.Data
         /// <summary>
         /// Returns true if the texture is editable
         /// </summary>
+        [JsonIgnore]
         public bool CanEditTexture
         {
             get
@@ -140,6 +146,15 @@ namespace DolphinDynamicInputTextureCreator.Data
             }
         }
         #endregion
+
+        public void SetInitialZoom(double absolutescale = 600)
+        {
+            if (ImageHeight <= 0 || ImageWidth <= 0)
+                return;
+
+            absolutescale /= (ImageHeight + ImageWidth) / 2;
+            ScaleFactor = absolutescale;
+        }
 
         #region COMMANDS
         private ICommand _delete_region_command;

--- a/Data/DynamicInputTexture.cs
+++ b/Data/DynamicInputTexture.cs
@@ -1,6 +1,7 @@
 ﻿using DolphinDynamicInputTextureCreator.Other;
 using Microsoft.Win32;
 using Newtonsoft.Json;
+using System;
 using System.Collections.ObjectModel;
 using System.Drawing;
 using System.IO;
@@ -140,12 +141,19 @@ namespace DolphinDynamicInputTextureCreator.Data
             }
             set
             {
-                _scale_factor = value;
+                _scale_factor = Smooth(value,2);
                 OnPropertyChanged(nameof(ScaleFactor));
-                Regions.ToList().ForEach(x => x.ScaleFactor = value);
+                Regions.ToList().ForEach(x => x.ScaleFactor = _scale_factor);
             }
         }
         #endregion
+
+        private double Smooth(double value, int accuracy)
+        {
+            double factor = ((int)value * 10).ToString().Length;
+            factor = Math.Pow(10, factor);
+            return Math.Round(value / factor, accuracy + 1) * factor;
+        }
 
         public void SetInitialZoom(double absolutescale = 600)
         {

--- a/Data/EmulatedDevice.cs
+++ b/Data/EmulatedDevice.cs
@@ -221,9 +221,25 @@ namespace DolphinDynamicInputTextureCreator.Data
             }
         }
 
+        [JsonIgnore]
+        public ICommand AddAllKeyCommand
+        {
+            get { return new RelayCommand(AddAllKey); }
+        }
+
+        private void AddAllKey(object obj)
+        {
+            string name;
+            while ((name = GetNextSugges()) != "")
+            {
+                AddKey(name);
+            }
+        }
+
         private void AddKey(object obj)
         {
-            string name = GetNextSugges();
+            string name;
+            name = obj == null ? GetNextSugges() : obj.ToString();
 
             EmulatedKeys.Add(
                 new EmulatedKey

--- a/Data/EmulatedDevice.cs
+++ b/Data/EmulatedDevice.cs
@@ -223,12 +223,39 @@ namespace DolphinDynamicInputTextureCreator.Data
 
         private void AddKey(object obj)
         {
+            string name = GetNextSugges();
+
             EmulatedKeys.Add(
                 new EmulatedKey
                 {
-                    Name = ""
+                    Name = name
                 });
         }
+
+        /// <summary>
+        /// Search for a key name that is not in use.
+        /// </summary>
+        private string GetNextSugges()
+        {
+            foreach (string suggestion in SearchSuggestions)
+            {
+                bool skip_suggestion = false;
+                foreach (EmulatedKey key in EmulatedKeys)
+                {
+                    // Skip suggestion when a match is found
+                    if (key.Name == suggestion)
+                    {
+                        skip_suggestion = true;
+                        break;
+                    }
+                }
+
+                if (!skip_suggestion)
+                    return suggestion;
+            }
+            return "";
+        }
         #endregion
+
     }
 }

--- a/Data/RegionBrush.cs
+++ b/Data/RegionBrush.cs
@@ -36,20 +36,6 @@ namespace DolphinDynamicInputTextureCreator.Data
         }
 
         /// <summary>
-        /// Whether to fill the entire image with the region
-        /// </summary>
-        private bool _fill_region;
-        public bool FillRegion
-        {
-            get { return _fill_region; }
-            set
-            {
-                _fill_region = value;
-                OnPropertyChanged(nameof(FillRegion));
-            }
-        }
-
-        /// <summary>
         /// whether subpixels are used.
         /// </summary>
         private bool _subpixel;

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -88,7 +88,7 @@
                         </Style>
                     </ComboBox.Style>
                 </ComboBox>
-                <CheckBox Margin="5 0 5 0" Content="Fill texture?" IsChecked="{Binding SelectedRegionBrush.FillRegion}" VerticalAlignment="Center" />
+                <Button Margin="5,0,5,0" MinWidth="35" Content="Fill Region" VerticalAlignment="Center" Click="ButtonFill_Click"/>
                 <CheckBox Margin="5 0 5 0" Content="Use subpixel?" IsChecked="{Binding SelectedRegionBrush.Subpixel}" VerticalAlignment="Center" />
             </StackPanel>
             <controls:PanZoom x:Name="PanZoom" Grid.Row="1"></controls:PanZoom>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -266,5 +266,9 @@ namespace DolphinDynamicInputTextureCreator
         }
         #endregion
 
+        private void ButtonFill_Click(object sender, RoutedEventArgs e)
+        {
+            PanZoom.ViewModel.FillRegion();
+        }
     }
 }

--- a/ViewModels/PanZoomViewModel.cs
+++ b/ViewModels/PanZoomViewModel.cs
@@ -69,6 +69,38 @@ namespace DolphinDynamicInputTextureCreator.ViewModels
         private System.Nullable<Point> _last_pan_position;
 
         /// <summary>
+        /// adds a filled region.
+        /// </summary>
+        public void FillRegion()
+        {
+            if (InputPack.SelectedRegionBrush.SelectedEmulatedDevice == null || InputPack.SelectedRegionBrush.SelectedEmulatedKey == null)
+            {
+                return;
+            }
+
+            Data.RectRegion f = new Data.RectRegion() { ScaleFactor = InputPack.EditingTexture.ScaleFactor, X = 0, Y = 0, Height = InputPack.EditingTexture.ImageHeight, Width = InputPack.EditingTexture.ImageWidth, Device = InputPack.SelectedRegionBrush.SelectedEmulatedDevice, Key = InputPack.SelectedRegionBrush.SelectedEmulatedKey, OwnedTexture = InputPack.EditingTexture };
+
+            //one fill region is enough
+            if (InputPack.EditingTexture.Regions.Count > 0)
+            {
+                foreach (Data.RectRegion r in InputPack.EditingTexture.Regions)
+                {
+                    if (r.X == f.X & r.Y == f.Y & r.Width == f.Width & r.Height == f.Height)
+                    {
+                        r.Device = f.Device;
+                        r.Key = f.Key;
+                    }
+                }
+
+                return;
+            }
+
+
+            InputPack.EditingTexture.Regions.Add(f);
+
+        }
+
+        /// <summary>
         /// Given a point, will create a new region if we did not click on a separate region
         /// </summary>
         /// <param name="p"></param>
@@ -90,21 +122,9 @@ namespace DolphinDynamicInputTextureCreator.ViewModels
                 }
             }
 
-            if (InputPack.SelectedRegionBrush.FillRegion)
-            {
-                _currently_creating_region = new Data.RectRegion() { ScaleFactor = InputPack.EditingTexture.ScaleFactor, X = 0, Y = 0, Height = InputPack.EditingTexture.ImageHeight, Width = InputPack.EditingTexture.ImageWidth, Device = InputPack.SelectedRegionBrush.SelectedEmulatedDevice, Key = InputPack.SelectedRegionBrush.SelectedEmulatedKey, OwnedTexture = InputPack.EditingTexture };
-            }
-            else
-            {
-                _currently_creating_region = new Data.RectRegion() { ScaleFactor = InputPack.EditingTexture.ScaleFactor, X = p.X, Y = p.Y, Height = 1, Width = 1, Device = InputPack.SelectedRegionBrush.SelectedEmulatedDevice, Key = InputPack.SelectedRegionBrush.SelectedEmulatedKey, OwnedTexture = InputPack.EditingTexture };
-            }
+            _currently_creating_region = new Data.RectRegion() { ScaleFactor = InputPack.EditingTexture.ScaleFactor, X = p.X, Y = p.Y, Height = 1, Width = 1, Device = InputPack.SelectedRegionBrush.SelectedEmulatedDevice, Key = InputPack.SelectedRegionBrush.SelectedEmulatedKey, OwnedTexture = InputPack.EditingTexture };
             InputPack.EditingTexture.Regions.Add(_currently_creating_region);
 
-            if (InputPack.SelectedRegionBrush.FillRegion)
-            {
-                // No need to continue, operation is finished
-                _currently_creating_region = null;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
required [Subpixels settings #13 ](https://github.com/iwubcode/DolphinDynamicInputTextureCreator/pull/13)

- "filled region" changed into a button.
- Allows to add textures via file drop.
- Allows to add HostKey textures via file drop.
- Automatically sets a name for new emulated device keys.
- Automatically adjusts the initial zoom of textures.
- Scroll behavior improved 
   > Mouse wheel = vertical scrolling
   > Mouse wheel + Shift = horizontal scrolling
   > Mouse wheel + Ctrl = zoom
- button added to add all emulated device keys at once
   > [issues #5](https://github.com/iwubcode/DolphinDynamicInputTextureCreator/issues/5)