### PR TITLE
Texture scaling during export

### DIFF
--- a/Controls/Metadata.xaml
+++ b/Controls/Metadata.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:DolphinDynamicInputTextureCreator.Controls"
+             xmlns:converters="clr-namespace:DolphinDynamicInputTextureCreator.ValueConverters"
              mc:Ignorable="d" 
              Height="220" Width="320">
     <Grid Background="White">
@@ -31,6 +32,8 @@
             <CheckBox IsChecked="{Binding PreserveAspectRatio, Mode=TwoWay}" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="4,0"/>
             <Label Content="Game ID:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" HorizontalContentAlignment="Right"/>
             <TextBox Text="{Binding GameID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="4,0"/>
+            <Label Content="Export Texture Scaling:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" HorizontalContentAlignment="Right"/>
+            <ComboBox ItemsSource="{Binding ExportTextureScalingModes}" SelectedItem="{Binding SelectedExportTextureScaling}" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="4,0"/>
 
         </Grid>
     </Grid>

--- a/DolphinDynamicInputTexture/Data/DynamicInputPack.cs
+++ b/DolphinDynamicInputTexture/Data/DynamicInputPack.cs
@@ -121,8 +121,8 @@ namespace DolphinDynamicInputTexture.Data
         /// <param name="location">export directory</param>
         public void ExportToLocation(string location)
         {
-            WriteJson(Path.Combine(location, GeneratedJsonName + ".json"));
             WriteImages(location);
+            WriteJson(Path.Combine(location, GeneratedJsonName + ".json"));
             WriteGameID(location);
         }
 
@@ -153,6 +153,7 @@ namespace DolphinDynamicInputTexture.Data
             {
                 //exports the images for the output_textures
                 WriteImage(location, texture);
+
                 foreach (HostDevice device in texture.HostDevices)
                 {
                     foreach (HostKey key in device.HostKeys)
@@ -164,7 +165,7 @@ namespace DolphinDynamicInputTexture.Data
             }
         }
 
-        private void WriteImage(string location, Interfaces.IImage image)
+        private void WriteImage(string location, IImage image)
         {
             // Unlikely that we get here but skip textures that don't exist
             if (!File.Exists(image.TexturePath))
@@ -174,13 +175,25 @@ namespace DolphinDynamicInputTexture.Data
             image.RelativeTexturePath = CheckRelativeTexturePath(image);
             string output_location = Path.Combine(location, image.RelativeTexturePath);
 
+            //create the directory when it does not exist.
+            Directory.CreateDirectory(Path.GetDirectoryName(output_location));
+
+            //Scaling of the texture if necessary
+            if (image is DynamicInputTexture texture)
+            {
+                if (texture.ExportImageScaling != 0 && texture.ExportImageScaling != texture.ImageWidthScaling)
+                {
+                    texture.SetImageScaling(output_location, texture.ExportImageScaling);
+                    return;
+                }
+            }
+
             // Prevents the file from trying to overwrite itself.
             if (Path.GetFullPath(output_location) == Path.GetFullPath(image.TexturePath))
                 return;
 
             //write the image
             const bool overwrite = true;
-            Directory.CreateDirectory(Path.GetDirectoryName(output_location));
             File.Copy(image.TexturePath, output_location, overwrite);
         }
 

--- a/ViewModels/Dialogs.cs
+++ b/ViewModels/Dialogs.cs
@@ -124,7 +124,10 @@ namespace DolphinDynamicInputTextureCreator.ViewModels
             var dialog = new System.Windows.Forms.FolderBrowserDialog();
             if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
+                pack.SetExportTextureScaling();
                 pack.ExportToLocation(dialog.SelectedPath);
+                // Updating the user interface in case the image file has changed.
+                pack.Textures.Select(pack.Textures.Selected);
                 return true;
             }
             return false;


### PR DESCRIPTION
enables the scaling of textures during export, the desired scaling can be set in the metadata window.

![grafik](https://user-images.githubusercontent.com/87765258/153674679-09f1d59f-57ff-44c3-b0f7-d4c3017d9f79.png)

**Deactivated** _(Default)_ - Leaves the textures unchanged and keeps the current size.
**Dynamic** - Calculates a good scaling size. (The smallest region of a texture is scaled to a specific pixel value.)
**1x** - **8x** - sets the texture scaling to the specified size.


possible improvement would be
**only scale up option**
**Setting the dynamic pixel value** _(at the moment 96 pixel)_